### PR TITLE
fixing browserstack report generation tab. fix around null buildNumbe…

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.browserstack.bamboo</groupId>
     <artifactId>browserstack-bamboo-integration</artifactId>
-    <version>1.0.5-SNAPSHOT</version>
+    <version>1.0.5</version>
 
     <name>BrowserStack Plugin for Bamboo</name>
     <packaging>atlassian-plugin</packaging>
@@ -39,7 +39,7 @@
         <connection>scm:git:git://github.com:browserstack/browserstack-bamboo-integration.git</connection>
         <developerConnection>scm:git:git@github.com:browserstack/browserstack-bamboo-integration.git</developerConnection>
         <url>git@github.com:browserstack/browserstack-bamboo-integration.git</url>
-        <tag>browserstack-bamboo-integration-1.0.0</tag>
+        <tag>browserstack-bamboo-integration-1.0.5</tag>
     </scm>
 
     <dependencies>

--- a/src/main/java/com/browserstack/bamboo/ci/action/BStackReport.java
+++ b/src/main/java/com/browserstack/bamboo/ci/action/BStackReport.java
@@ -3,13 +3,11 @@ package com.browserstack.bamboo.ci.action;
 import com.atlassian.bamboo.plan.cache.ImmutableChain;
 import com.atlassian.bamboo.plan.cache.ImmutableJob;
 import com.atlassian.bamboo.plan.cache.ImmutablePlan;
-import com.atlassian.bamboo.build.ViewBuildResults;
+import com.atlassian.bamboo.build.PlanResultsAction;
 import com.atlassian.bamboo.configuration.SystemInfo;
 import com.atlassian.spring.container.LazyComponentReference;
-import com.atlassian.bamboo.configuration.AdministrationConfiguration;
 import com.atlassian.bamboo.configuration.AdministrationConfigurationAccessor;
 import java.util.List;
-import java.util.Map;
 import java.util.ArrayList;
 
 import com.browserstack.bamboo.ci.lib.BStackXMLReportParser;
@@ -27,14 +25,14 @@ import com.browserstack.appautomate.AppAutomateClient;
 /**
  * @author Pulkit Sharma
  */
-public class BStackReport extends ViewBuildResults {
+public class BStackReport extends PlanResultsAction {
 
     private List<BStackSession> bStackSessions;
 
     private AdministrationConfigurationAccessor administrationConfigurationAccessor;
 
     String buildNumber;
-
+    Boolean hasBStackReports;
     private BandanaManager bandanaManager;
 
     
@@ -63,16 +61,24 @@ public class BStackReport extends ViewBuildResults {
         }
       }
 
-      return super.doDefault();
+      return super.execute();
     }
 
-    public boolean getHasBStackReports() {
-      return (bStackSessions.size() > 0);
+    public String execute() throws Exception {
+      return doDefault();
     }
 
     public List<BStackSession> getSessions() {
 
       return bStackSessions;
+    }
+
+    public Boolean getHasBStackReports() {
+      return hasBStackReports;
+    }
+
+    public void setHasBStackReports(Boolean hasBStackReports) {
+      this.hasBStackReports = hasBStackReports;
     }
 
     private void AddBStackSessions(String baseDirectory, ImmutableJob job) {
@@ -94,12 +100,17 @@ public class BStackReport extends ViewBuildResults {
         BStackJUnitSessionMapper sessionMapper = new BStackJUnitSessionMapper(directoryToScan, bStackParser.getTestSessionMap(), automateClient, appAutomateClient);
 
         bStackSessions.addAll(sessionMapper.parseAndMapJUnitXMLReports());
-      } 
+      }
       
+      hasBStackReports = bStackSessions.size() > 0;
     }
 
     public void setBuildNumber(String buildNumber){
       this.buildNumber = buildNumber;
+    }
+
+    public java.lang.Integer getBuildNumber() {
+      return Integer.parseInt(buildNumber);
     }
 
     public AdministrationConfigurationAccessor getAdministrationConfigurationAccessor() {


### PR DESCRIPTION
Issues fixed in this PR : 
- Report generation tab breaking with a message around key not found. Changed the class we extend for report collection.
- Creating an issue on JIRA requires build number which was null/missing as the getter function was missing.
- Tested the plugin on **6.10.3, 6.9.0, 6.8.0, 6.5.1, 6.2.9, 5.13.2** and it works.