### PR TITLE
Fix Browserstack reporting for TestNG and JUnit

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -105,7 +105,7 @@
             <version>0.7</version>
         </dependency>
 
-	<dependency>
+	    <dependency>
            <groupId>org.apache.httpcomponents</groupId>
             <artifactId>httpclient</artifactId>
             <version>4.5.9</version>

--- a/pom.xml
+++ b/pom.xml
@@ -102,7 +102,13 @@
         <dependency>
             <groupId>com.browserstack</groupId>
             <artifactId>automate-client-java</artifactId>
-            <version>0.3</version>
+            <version>0.7</version>
+        </dependency>
+
+	<dependency>
+           <groupId>org.apache.httpcomponents</groupId>
+            <artifactId>httpclient</artifactId>
+            <version>4.5.9</version>
         </dependency>
 
         <dependency>

--- a/src/main/resources/templates/BStackReport.ftl
+++ b/src/main/resources/templates/BStackReport.ftl
@@ -99,5 +99,5 @@
         </script>
     [#else]
         <p> No BrowserStack Reports found.</p>
-        <a target="_blank" href="https://www.browserstack.com/automate/bamboo#reporting">View your BrowserStack test reports in Bamboo.</href>
+        <a target="_blank" href="https://www.browserstack.com/docs/automate/selenium/bamboo#generating-and-embedding-test-reportsfor-junit-and-testng-only">View your BrowserStack test reports in Bamboo.</href>
     [/#if]


### PR DESCRIPTION
Fixes Browserstack reporting not working for Bamboo plugin.
Ideally, Bamboo reports should look like 
![image](https://user-images.githubusercontent.com/14837478/103407092-411ab380-4b83-11eb-9392-0482338a7f83.png)


![image](https://user-images.githubusercontent.com/14837478/103407113-51329300-4b83-11eb-9ee3-291d7012afc5.png)

